### PR TITLE
Add support for 'scheduled'

### DIFF
--- a/taskhuddler/task.py
+++ b/taskhuddler/task.py
@@ -28,6 +28,21 @@ class Task(object):
         return self.state == 'completed'
 
     @property
+    def scheduled(self):
+        """What time did the most recent run get scheduled?
+        (aka: what time did it move from unscheduled to pending?)
+        Field looks like:
+        "scheduled": "2017-10-26T01:03:59.291Z",
+        Returns: datetime object of start time, or None if not applicable
+        """
+        if not self.json['status'].get('runs'):
+            return
+        scheduled = self.json['status']['runs'][-1].get('scheduled')
+        if not scheduled:
+            return
+        return dateutil.parser.parse(scheduled)
+
+    @property
     def started(self):
         """What time did the most recent run start?
         Field looks like:

--- a/taskhuddler/test/test_task.py
+++ b/taskhuddler/test/test_task.py
@@ -40,6 +40,16 @@ def test_task_state_completed(filename, expected):
 
 
 @pytest.mark.parametrize('filename,expected', (
+    ['completed.json', dateutil.parser.parse('2017-10-26T01:03:58.641Z')],
+    ['unscheduled.json', None],
+    ['missing.json', dateutil.parser.parse('2017-10-26T01:09:00.750Z')]
+))
+def test_task_scheduled(filename, expected):
+    task = Task(json=get_dummy_task_json(filename))
+    assert task.scheduled == expected
+
+
+@pytest.mark.parametrize('filename,expected', (
     ['completed.json', dateutil.parser.parse('2017-10-26T01:03:59.291Z')],
     ['unscheduled.json', None],
     ['missing.json', None]


### PR DESCRIPTION
Useful data to have if you're trying to find bottlenecks! (started - scheduled) = wait time.